### PR TITLE
1.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26 AS builder
+FROM golang:1.27 AS builder
 
 LABEL maintainer="Alex <github.com/alkmc>"
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/alkmc/news-proxy
 
-go 1.26
+go 1.27

--- a/internal/httpapi/router_test.go
+++ b/internal/httpapi/router_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/alkmc/news-proxy/ui"
 )
 
+// testHost can be any absolute URL, the in-memory test server answers regardless of the host.
+const testHost = "http://newsproxy.test"
+
 func TestRouter(t *testing.T) {
 	t.Parallel()
 
@@ -101,7 +104,7 @@ func TestRouter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ts := newTestServer(t, tc.client)
+			ts := testServer(t, tc.client)
 			status, headers, body := get(t, ts, tc.path)
 
 			if status != tc.wantStatus {
@@ -122,9 +125,9 @@ func TestRouter(t *testing.T) {
 func TestRouter_HTMXPartial(t *testing.T) {
 	t.Parallel()
 
-	ts := newTestServer(t, &mockNewsClient{mockFetchFn: mockFetchResponse(5)})
+	ts := testServer(t, &mockNewsClient{mockFetchFn: mockFetchResponse(5)})
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"/search?q=golang", nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, testHost+"/search?q=golang", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,8 +154,8 @@ func TestRouter_HTMXPartial(t *testing.T) {
 	}
 }
 
-// newTestServer starts the full router with the real template and a mock client.
-func newTestServer(t *testing.T, client fetcher) *httptest.Server {
+// serveRouter builds the full router with the real template and a mock client.
+func testServer(t *testing.T, client fetcher) *httptest.Server {
 	t.Helper()
 
 	tpl, err := view.ParseTemplate(ui.TemplateFS)
@@ -161,15 +164,13 @@ func newTestServer(t *testing.T, client fetcher) *httptest.Server {
 	}
 	logger := slog.New(slog.DiscardHandler)
 	h := NewHandler(client, view.NewRenderer(tpl, logger), logger, 10, 100)
-	ts := httptest.NewServer(NewMux(h))
-	t.Cleanup(ts.Close)
-	return ts
+	return httptest.NewTestServer(t, NewMux(h))
 }
 
 func get(t *testing.T, ts *httptest.Server, path string) (int, http.Header, string) {
 	t.Helper()
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+path, nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, testHost+path, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/newsapi/client.go
+++ b/internal/newsapi/client.go
@@ -2,7 +2,7 @@ package newsapi
 
 import (
 	"context"
-	"encoding/json"
+	"encoding/json/v2"
 	"errors"
 	"fmt"
 	"io"
@@ -15,21 +15,22 @@ import (
 // maxBodyBytes caps how much of an upstream response body is read.
 const maxBodyBytes = 1 << 20
 
-// Client calls the NewsAPI /v2/everything endpoint with bounded paging.
-type Client struct {
-	baseParsedURL *url.URL
-	apiKey        string
-	pageSize      int
-	httpClient    *http.Client
-}
-
-// Config configures the API Client.
-type Config struct {
-	BaseURL  string
-	APIKey   string
-	PageSize int
-	Timeout  time.Duration
-}
+type (
+	// Client calls the NewsAPI /v2/everything endpoint with bounded paging.
+	Client struct {
+		baseParsedURL *url.URL
+		apiKey        string
+		pageSize      int
+		httpClient    *http.Client
+	}
+	// Config configures the API Client.
+	Config struct {
+		BaseURL  string
+		APIKey   string
+		PageSize int
+		Timeout  time.Duration
+	}
+)
 
 // NewClient parses the base URL and returns a configured Client.
 func NewClient(cfg Config) (*Client, error) {
@@ -93,7 +94,7 @@ func (c *Client) fetch(ctx context.Context, endpoint string, res *Results) error
 	}
 
 	body := io.LimitReader(resp.Body, maxBodyBytes)
-	if err := json.NewDecoder(body).Decode(res); err != nil {
+	if err := json.UnmarshalRead(body, res); err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidResponse, err)
 	}
 	if res.Status != "ok" {
@@ -119,7 +120,7 @@ func decodeUpstreamError(resp *http.Response) error {
 
 	body := io.LimitReader(resp.Body, maxBodyBytes)
 	var apiErr apiError
-	if err := json.NewDecoder(body).Decode(&apiErr); err != nil {
+	if err := json.UnmarshalRead(body, &apiErr); err != nil {
 		return fmt.Errorf("%w: status %d: failed to decode body: %w", sentinel, resp.StatusCode, err)
 	}
 	return fmt.Errorf("%w: status %d: %s", sentinel, resp.StatusCode, apiErr.Message)


### PR DESCRIPTION
- Go@1.27
- migrate to encoding/json/v2
- use httptest.NewTestServer